### PR TITLE
Update README.md: Include Wayland instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Start UI:
 * Open terminal and go to specific folder
 * Type: `python3 -m tlpui`
 
+> Note: If you run Wayland you have to use `pkexec` instead of `sudo`. Example: `pkexec cd ~/Downloads/TLPUI && python3 -m tlpui`.
+
 Current status:
 
 * Software still in Beta status


### PR DESCRIPTION
I use Fedora which uses Wayland. In Wayland it is not possible to run GUI apps with sudo.

I included in the README.md file the command "`pkexec cd ~/Downloads/TLPUI && python3 -m tlpui`" so that someone can easily run `tlpui` on Wayland.