### PR TITLE
Update Flatpak README to install build dependencies

### DIFF
--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build-dir/

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -2,13 +2,13 @@
 
 Until TLPUI flatpak will be released on https://flathub.org you have to build it yourself. Please follow the steps below:
 
-1. Make sure you have runtime and SDK installed like this:
+1. Make sure you have the Flathub repository installed like this:
 
-  `flatpak install flathub org.gnome.Platform//3.38 org.gnome.Sdk//3.38`
+  `flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`
 
 2. To build and install the Flatpak in user environment you can call from inside the **flatpak** folder:
 
-  `flatpak-builder --force-clean --user --install build-dir com.github.d4nj1.tlpui.json`
+  `flatpak-builder --force-clean --user --install-deps-from flathub --install build-dir com.github.d4nj1.tlpui.json`
 
 3. To run the Flatpak execute:
 


### PR DESCRIPTION
The current build instructions fail when the GNOME runtime isn't installed. This patch updates the build instructions so that dependencies are also installed.