### PR TITLE
Fixing an error when building the package on some distros

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url="https://github.com/d4nj1/TLPUI",
     license="GPLv2",
     packages=["tlpui", "tlpui.ui_config_objects"],
+    long_description="The Python scripts in this project generate a GTK-UI to change TLP configuration files easily"
     package_data={'tlpui': [
         'styles.css',
         'configschema/*.json',


### PR DESCRIPTION
Adding the long_description field to setup.py to fix issues when building the app on some debian based distros. This patch fixes this issue:

https://github.com/d4nj1/TLPUI/issues/105