### PR TITLE
Fixed location of desktop file after install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
         ]
     },
     data_files=[
-        ('/usr/share/applications', ["tlpui.desktop"])
+        ('share/applications', ["tlpui.desktop"])
     ]
 )


### PR DESCRIPTION
Hi, I`m packaging TLPUI for [ALT Linux](https://packages.altlinux.org/en/sisyphus/) repository.

If we run next commands:
`/usr/bin/python3 -m pyproject_installer -v build`
`/usr/bin/python3 -m pyproject_installer -v install --destdir=%buildroot`

The .desktop file will be located in usr/lib/python3/site-packages/usr/share/applications/ instead of just usr/share/applications 
This patch puts the file in the right place