### PR TITLE
patched charge thresh to allow conservation mode

### DIFF
--- a/tlpui/configschema/1_4.json
+++ b/tlpui/configschema/1_4.json
@@ -699,7 +699,7 @@
             {
               "id": "STOP_CHARGE_THRESH_BAT0",
               "type": "numeric",
-              "values": "5-100"
+              "values": "1-100"
             }
           ]
         },
@@ -714,7 +714,7 @@
             {
               "id": "STOP_CHARGE_THRESH_BAT1",
               "type": "numeric",
-              "values": "5-100"
+              "values": "0-100"
             }
           ]
         },

--- a/tlpui/configschema/1_5.json
+++ b/tlpui/configschema/1_5.json
@@ -76,7 +76,7 @@
         {
           "group": "MAX_LOST_WORK_SECS",
           "ids": [
-              {
+            {
               "id": "MAX_LOST_WORK_SECS_ON_AC",
               "type": "numeric",
               "values": "0-10000"
@@ -699,7 +699,7 @@
             {
               "id": "STOP_CHARGE_THRESH_BAT0",
               "type": "numeric",
-              "values": "5-100"
+              "values": "1-100"
             }
           ]
         },
@@ -714,7 +714,7 @@
             {
               "id": "STOP_CHARGE_THRESH_BAT1",
               "type": "numeric",
-              "values": "5-100"
+              "values": "0-100"
             }
           ]
         },


### PR DESCRIPTION
From TLP version 1.4 to enable battery conservation mode on some vendor supported hardware the `STOP_CHARGE_THRESH_BAT0` field needs to be set at '1' but the configschema denies values below 5.

The documentation reports:

- Lenovo non-ThinkPad series (like ideapad): stop threshold values: 
**1** - battery charges to 60% **(battery conservation mode on!)**
**0** - battery charges to 100%, battery conservation mode off
- LG Gram laptops and Samsung laptops: same; stop threshold value '1' means "battery charges to 80%".

Therefore, I have edited the configschema of TLP versions 1.4 and 1.5 to allow the value '1' on `STOP_CHARGE_THRESH_BAT0` and '0' on `STOP_CHARGE_THRESH_BAT1` like the docs do.



