### PR TITLE
Fixed activeposition in test/test_tlp_settings.py

### DIFF
--- a/test/test_tlp_settings.py
+++ b/test/test_tlp_settings.py
@@ -18,7 +18,7 @@ class MyTestCase(unittest.TestCase):
         assert linecache.getline(str(userconfig.userconfigfile), 2) == "language = en_EN\n"
         assert linecache.getline(str(userconfig.userconfigfile), 3) == "activeoption = 0\n"
         assert linecache.getline(str(userconfig.userconfigfile), 4) == "activecategory = 0\n"
-        assert linecache.getline(str(userconfig.userconfigfile), 5) == "activeposition = 0.0\n"
+        assert linecache.getline(str(userconfig.userconfigfile), 5) == "activeposition = 0\n"
         assert linecache.getline(str(userconfig.userconfigfile), 6) == "windowxsize = 900\n"
         assert linecache.getline(str(userconfig.userconfigfile), 7) == "windowysize = 600\n"
 


### PR DESCRIPTION
Looks like a typo in the tests
An error occurs during the testing phase. Log is attached.

[broken_test.log](https://github.com/d4nj1/TLPUI/files/13166200/broken_test.log)
