### PR TITLE
#102 Amend values for battery conservation to support all vendors

### DIFF
--- a/tlpui/configschema/1_4.yaml
+++ b/tlpui/configschema/1_4.yaml
@@ -378,18 +378,18 @@ categories:
         ids:
           - id: START_CHARGE_THRESH_BAT0
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT0
             type: numeric
-            values: 5-100
+            values: 0-100
       - group: CHARGE_THRESH_BAT1
         ids:
           - id: START_CHARGE_THRESH_BAT1
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT1
             type: numeric
-            values: 5-100
+            values: 0-100
       - id: RESTORE_THRESHOLDS_ON_BAT
         type: bselect
         values: 0,1

--- a/tlpui/configschema/1_5.yaml
+++ b/tlpui/configschema/1_5.yaml
@@ -378,18 +378,18 @@ categories:
         ids:
           - id: START_CHARGE_THRESH_BAT0
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT0
             type: numeric
-            values: 5-100
+            values: 0-100
       - group: CHARGE_THRESH_BAT1
         ids:
           - id: START_CHARGE_THRESH_BAT1
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT1
             type: numeric
-            values: 5-100
+            values: 0-100
       - id: RESTORE_THRESHOLDS_ON_BAT
         type: bselect
         values: 0,1

--- a/tlpui/configschema/1_6.yaml
+++ b/tlpui/configschema/1_6.yaml
@@ -386,18 +386,18 @@ categories:
         ids:
           - id: START_CHARGE_THRESH_BAT0
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT0
             type: numeric
-            values: 5-100
+            values: 0-100
       - group: CHARGE_THRESH_BAT1
         ids:
           - id: START_CHARGE_THRESH_BAT1
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT1
             type: numeric
-            values: 5-100
+            values: 0-100
       - id: RESTORE_THRESHOLDS_ON_BAT
         type: bselect
         values: 0,1

--- a/tlpui/configschema/1_7.yaml
+++ b/tlpui/configschema/1_7.yaml
@@ -377,18 +377,18 @@ categories:
         ids:
           - id: START_CHARGE_THRESH_BAT0
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT0
             type: numeric
-            values: 5-100
+            values: 0-100
       - group: CHARGE_THRESH_BAT1
         ids:
           - id: START_CHARGE_THRESH_BAT1
             type: numeric
-            values: 0-96
+            values: 0-99
           - id: STOP_CHARGE_THRESH_BAT1
             type: numeric
-            values: 5-100
+            values: 0-100
       - id: RESTORE_THRESHOLDS_ON_BAT
         type: bselect
         values: 0,1


### PR DESCRIPTION
In regards to #102 and #134 I would change the thresholds for

**START_CHARGE_THRESH_BAT0/1** and **STOP_CHARGE_THRESH_BAT0/1**

as documented in https://linrunner.de/tlp/faq/battery.html#are-thinkpads-with-coreboot-supported

```
Parameter value ranges:
* START_CHARGE_THRESH_BAT0/1:  0(off)..96(default)..99
* STOP_CHARGE_THRESH_BAT0/1:   1..100(default)
```

Also from the config file itself:
```
# - Vendor specific parameter value ranges are shown by tlp-stat -b
# - If your hardware supports a start *and* a stop threshold, you must
#   specify both, otherwise TLP will refuse to apply the single threshold
# - If your hardware supports only a stop threshold, set the start value to 0
```